### PR TITLE
fix typo `excactSmooth` - the command is calling `exactSmooth`

### DIFF
--- a/includesDev/cap12.tex
+++ b/includesDev/cap12.tex
@@ -749,7 +749,7 @@ switchBinary&	level, icon, title	&on, off or update	&apiURL/devices/:deviceId/co
 \hline
 switchMultilevel	&level, icon, title	& on Set(255), off Set(0), min Set(10), max Set(99), increase Set(l+10), decrease Set(l-10), update, exact + get params level	&apiURL/devices/:deviceId/command/exact? level=40 \\
 \hline
-switchMultilevel (Blinds)&	level, icon, title	&up Set(255), down Set(0), upMax Set(99), increase Set(l+10), decrease Set(l-10), startUp StartLevelChange(0), startDown StartLevelChange(1), stop StopLevelChange(), update, excactSmooth + get params level	& apiURL/devices/:deviceId/command/stop  \\
+switchMultilevel (Blinds)&	level, icon, title	&up Set(255), down Set(0), upMax Set(99), increase Set(l+10), decrease Set(l-10), startUp StartLevelChange(0), startDown StartLevelChange(1), stop StopLevelChange(), update, exactSmooth + get params level	& apiURL/devices/:deviceId/command/stop  \\
 \hline
 sensorBinary	&probeTitle, level, icon, title	&update	&apiURL/devices/:deviceId/command/update\\
 \hline


### PR DESCRIPTION
As subject says, it fixes typo in command name for switchMultilevel (Blinds) in manual:
```diff
-excactSmooth
+exactSmooth
```
